### PR TITLE
Update RNCC blank javascript template

### DIFF
--- a/react-native-template-blank/package.json
+++ b/react-native-template-blank/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daileytj/react-native-template-blank",
-  "version": "0.0.1-beta.3",
+  "version": "0.0.1-beta.4",
   "description": "Blank Javascript React Native Template",
   "license": "BSD-3-Clause"
 }

--- a/react-native-template-blank/template/ios/Podfile
+++ b/react-native-template-blank/template/ios/Podfile
@@ -19,13 +19,6 @@ target 'ReactNativeTemplateBlank' do
   # you should disable these next few lines.
   use_flipper!
   post_install do |installer|
-    # Remove IPHONEOS_DEPLOYMENT_TARGET setting
-    installer.pods_project.targets.each do |target|
-      target.build_configurations.each do |config|
-        config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'
-      end
-    end
-  
     flipper_post_install(installer)
   end
 end


### PR DESCRIPTION
- Remove script to remove iphoneos deployment target settings
- Update RNCC blank javascript template version to 0.0.1-beta-4